### PR TITLE
adds logging to kodawari.authentication

### DIFF
--- a/py/lib/kodawari.authentication/authentication/authentication.py
+++ b/py/lib/kodawari.authentication/authentication/authentication.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from os import getenv
 from typing import Any, Dict
@@ -5,11 +6,13 @@ from typing import Any, Dict
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import InvalidSignatureError, decode
+from logging_utilities.utilities import get_logger
 from pydantic import BaseModel
 
 _secret_environment_variable = "KODAWARI_SECRET_KEY"
 _bearer_token_algorithms = ["HS256"]
 _security_scheme = HTTPBearer()
+_logger: logging.Logger = get_logger(__name__, logging.DEBUG)
 
 
 class BearerValidationException(Exception):
@@ -92,5 +95,6 @@ async def authenticate(
         return bearer_claims
     except (BearerValidationException, InvalidSignatureError):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
-    except:
+    except Exception:
+        _logger.exception("An unexpected error occurred during authentication.")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/py/lib/kodawari.authentication/poetry.lock
+++ b/py/lib/kodawari.authentication/poetry.lock
@@ -248,6 +248,20 @@ plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
+name = "kodawari-logging-utilities"
+version = "0.1.0"
+description = "Logging utilities for Kodawari services"
+category = "main"
+optional = false
+python-versions = "^3.11"
+files = []
+develop = true
+
+[package.source]
+type = "directory"
+url = "../kodawari.logging_utilities"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -555,4 +569,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c8d039c90b578a657593635ecd44ef9c048c64aee30781033c80384ac947268b"
+content-hash = "2cd83b2646e15f79b1cc6715a9e13c25a53124210645c7a30f570a4fc3652e10"

--- a/py/lib/kodawari.authentication/pyproject.toml
+++ b/py/lib/kodawari.authentication/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.11"
 fastapi = "^0.89.1"
 pydantic = "^1.10.4"
 PyJWT = "^2.6.0"
+kodawari-logging-utilities = {path = "../kodawari.logging_utilities", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
This change set adds logging to kodawari.authentication, which is required to log unexpected exceptions because authentication.authenticate is injected as a Dependency into FastAPI routes. This makes handling, subsequently logging, out of the control of our FastAPI routes.